### PR TITLE
fix: Members can only use .whened after .when

### DIFF
--- a/src/commands/a350x/when.ts
+++ b/src/commands/a350x/when.ts
@@ -2,6 +2,8 @@ import Discord from 'discord.js';
 import { CommandCategories, CommandDefinition } from '../index';
 import { color } from '../../index';
 
+export let whenedAvailable;
+
 export const when: CommandDefinition = {
     names: ['when'],
     description: "Explains how we don't know when the A350X will release",
@@ -18,5 +20,11 @@ export const when: CommandDefinition = {
             );
 
         await message.channel.send({ embeds: [embed] }).catch(console.error);
+
+        setWhenedAvailable(true);
     },
+};
+
+export const setWhenedAvailable = (avail: boolean) => {
+    whenedAvailable = avail;
 };

--- a/src/commands/fun/whened.ts
+++ b/src/commands/fun/whened.ts
@@ -1,14 +1,22 @@
 import Discord from 'discord.js';
-import { CommandCategories, CommandDefinition } from '../index';
+import { CommandCategories, CommandDefinition, createErrorEmbed } from '../index';
 import { color } from '../../index';
+import { whenedAvailable, setWhenedAvailable } from '../a350x/when';
 
 export const whened: CommandDefinition = {
     names: ['whened'],
     description: 'Laughs at the user that got the .when',
     category: CommandCategories.FUN,
     execute: async (message, args) => {
+        if (!whenedAvailable) {
+            await message.channel.send({ embeds: [createErrorEmbed('You need to .when someone first')] });
+            return;
+        }
+
         const embed = new Discord.MessageEmbed().setColor(color).setImage('https://media.discordapp.net/attachments/740722295009706034/907005439579914340/meme.png');
 
         await message.channel.send({ embeds: [embed] }).catch(console.error);
+
+        setWhenedAvailable(false);
     },
 };


### PR DESCRIPTION
## Description

Members can now only use .whened after .when is used. This will prevent any spam that can occur with .whened

## Test Results

![image](https://media.discordapp.net/attachments/842374824936079370/930966996659630170/unknown.png?width=513&height=675)

## Discord Username

Dynamic#6030