### PR TITLE
feat: delete crypto scam messages

### DIFF
--- a/src/utils/cryptoScamDelete.ts
+++ b/src/utils/cryptoScamDelete.ts
@@ -5,9 +5,19 @@ export const cryptoScamDelete: UtilDefinition = {
     event: 'messageCreate',
     execute: async (message: Discord.Message) => {
         if (message.channel.type === Discord.ChannelType.DM) return;
-
         const content = message.content.toLowerCase();
-        if (content.includes('earn') && content.includes('crypto market')) {
+
+        // basic filter
+        if (!content.includes('earn') || !content.includes('crypto market')) {
+            return;
+        }
+
+        if (
+            content.includes('https://') ||
+            message.content.includes('WhatsApp') ||
+            message.content.includes('Telegram') ||
+            content.includes('commission')
+        ) {
             await message.delete().catch(console.error);
         }
     },

--- a/src/utils/cryptoScamDelete.ts
+++ b/src/utils/cryptoScamDelete.ts
@@ -1,0 +1,14 @@
+import Discord from 'discord.js';
+import { UtilDefinition } from '.';
+
+export const cryptoScamDelete: UtilDefinition = {
+    event: 'messageCreate',
+    execute: async (message: Discord.Message) => {
+        if (message.channel.type === Discord.ChannelType.DM) return;
+
+        const content = message.content.toLowerCase();
+        if (content.includes('earn') && content.includes('crypto market')) {
+            await message.delete().catch(console.error);
+        }
+    },
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { ClientEvents } from 'discord.js';
 import { autoKick } from './autoKick';
 import { autoWhen } from './autoWhen';
+import { cryptoScamDelete } from './cryptoScamDelete';
 import { joinMessages, leaveMessages } from './joinLeave';
 import { memberCounter } from './memberCounter';
 import { addRole, removeRole } from './reactionRoles';
@@ -10,4 +11,4 @@ export interface UtilDefinition {
     execute: (...args: any[]) => void;
 }
 
-export default [addRole, autoKick, autoWhen, joinMessages, leaveMessages, memberCounter, removeRole];
+export default [addRole, autoKick, autoWhen, cryptoScamDelete, joinMessages, leaveMessages, memberCounter, removeRole];


### PR DESCRIPTION
## Description

It works by checking the content of all sent messages. If the sent message includes both strings "earn" and "crypto market", as well as a link or some kind of social media (whatsapp/telegram), the message will automatically be deleted. It will not kick/ban the user in case of a false positive (but why would that ever happen)