### PR TITLE
fix: qna deleter doesn't halt cmd exec + DM message delete timer too short 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,10 +117,13 @@ client.on('messageCreate', async (message) => {
 
                 setTimeout(async () => {
                     await dmMessage.delete().catch(console.error);
-                }, 5000);
+                }, 120000);
+
             } catch (error) {
                 console.error(error);
             }
+
+            return; //stop execution of cmd
         }
     }
 


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Adds a missing `return` that didn't prevent command execution. Changed the DM notification from 5 seconds to 2 minutes.
