### PR TITLE
feat: Add health check endpoint for monitoring bot status

### DIFF
--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,47 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { Client } from 'discord.js';
+import mongoose from 'mongoose';
+
+/**
+ * Starts a simple HTTP health check server
+ * @param client - Discord client instance to check connection status
+ */
+export function startHealthServer(client: Client): void {
+    const port = process.env.HEALTH_PORT ? parseInt(process.env.HEALTH_PORT) : 3000;
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+        if (req.url === '/health' && req.method === 'GET') {
+            handleHealthCheck(client, res);
+        } else {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('Not Found');
+        }
+    });
+
+    server.listen(port, () => {
+        console.log(`Health check server listening on port ${port}`);
+    });
+
+    server.on('error', (error) => {
+        console.error('Health check server error:', error);
+    });
+}
+
+/**
+ * Handles the /health endpoint request
+ * Checks Discord bot and database connectivity
+ */
+function handleHealthCheck(client: Client, res: ServerResponse): void {
+    const discordHealthy = client.isReady();
+    const dbHealthy = mongoose.connection.readyState === 1; // 1 = connected
+
+    const isHealthy = discordHealthy && dbHealthy;
+
+    if (isHealthy) {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('OK');
+    } else {
+        res.writeHead(503, { 'Content-Type': 'text/plain' });
+        res.end('ERROR');
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { commands } from './commands';
 import { createEmbed } from './lib/embed';
 import logs from './logging';
 import utils from './utils';
+import { startHealthServer } from './health';
 
 dotenv.config();
 
@@ -20,6 +21,7 @@ const prefix = '.';
 
 client.on('ready', (client) => {
     console.log(`Bot is logged in as "${client.user.tag}"!`);
+    startHealthServer(client);
 });
 
 for (const log of logs) {


### PR DESCRIPTION
## Description

Added a health check HTTP server that monitors the Discord bot's operational status. This enables the monitoring systems for Coolify verify that the bot is running and properly connected to both Discord and the database.

What was added:
- New `/health` endpoint that returns HTTP 200 (OK) when the bot is healthy, or HTTP 503 (ERROR) when unhealthy
- Health checks verify:
  - Discord client connection status (client.isReady())
  - MongoDB/Mongoose database connection (readyState === 1)
- Configurable port via HEALTH_PORT environment variable (defaults to 3000)
- Automatic server startup when the bot's ready event fires


## Discord Username

alepouna