### PR TITLE
feat: Add autorole on boot for members without roles

### DIFF
--- a/src/utils/autoroleOnBoot.ts
+++ b/src/utils/autoroleOnBoot.ts
@@ -1,0 +1,22 @@
+import { Client, GuildMember } from 'discord.js';
+import { UtilDefinition } from './index';
+
+const DEFAULT_ROLE_ID = '808792283515191326';
+
+export const autoroleOnBoot: UtilDefinition = {
+    event: 'ready',
+    execute: async (client: Client) => {
+        const guild = client.guilds.cache.first();
+        if (!guild) return;
+
+        const members = await guild.members.fetch();
+        const role = await guild.roles.fetch(DEFAULT_ROLE_ID);
+        if (!role) return;
+
+        members.forEach(async (member: GuildMember) => {
+            if (member.roles.cache.size === 1 && !member.user.bot) {
+                await member.roles.add(role).catch(console.error);
+            }
+        });
+    },
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 import { ClientEvents } from 'discord.js';
 import { autoKick } from './autoKick';
+import { autoroleOnBoot } from './autoroleOnBoot';
 import { cryptoScamDelete } from './cryptoScamDelete';
 import { joinMessages, leaveMessages } from './joinLeave';
 import { memberCounter } from './memberCounter';
@@ -10,4 +11,4 @@ export interface UtilDefinition {
     execute: (...args: any[]) => void;
 }
 
-export default [addRole, autoKick, cryptoScamDelete, joinMessages, leaveMessages, memberCounter, removeRole];
+export default [addRole, autoKick, autoroleOnBoot, cryptoScamDelete, joinMessages, leaveMessages, memberCounter, removeRole];


### PR DESCRIPTION
## Description

Added a new utility that automatically assigns a default role to members who don't have any roles when the bot starts up.

Essentially: 
- Runs on the `ready` event when the bot boots/starts
- Fetches all members in the guild
- Checks each member to see if they only have the `@everyone` role (no other roles)
- Assigns role ID `808792283515191326` to qualifying members

**Note:** The role ID is hardcoded as mentioned - there's another PR (#36) that will make these constants, so this is intentional for now.

## Discord Username

alepouna