### PR TITLE
ci: split quality checks into separate jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,14 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  quality:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -25,8 +30,56 @@ jobs:
       - name: Run Biome checks
         run: bun run check
 
+  markdown:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Lint Markdown
         run: bun run lint:md
+
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "lint": "biome lint .",
         "lint:md": "markdownlint-cli2 \"**/*.md\"",
         "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
+        "typecheck": "tsc --noEmit",
         "prepare": "husky || true"
     },
     "lint-staged": {


### PR DESCRIPTION
## What changed
- split the existing CI workflow into separate `lint`, `markdown`, `typecheck`, and `build` jobs
- kept the workflow running on both pull requests and pushes to `master`
- added `workflow_dispatch` and concurrency cancellation for cleaner reruns
- added a dedicated `typecheck` script so CI can report type-check status separately from the build

## Why
- make GitHub checks easier to read and easier to require individually in branch protection
- let failures point directly at the specific category that broke instead of hiding inside one serial job
- keep PR validation and post-merge validation aligned